### PR TITLE
Fix link formatting for real

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -40,6 +40,6 @@ attribution-noncommercial-sharealike 2.0 license</a>.
 </p>
 </dd>
   </div>
-<p>
-[Download]({{ "/papers/Trike_v1_Methodology_Document-draft.pdf" | relative_url }})
-</p>
+
+<a href="{{ "/papers/Trike_v1_Methodology_Document-draft.pdf" | relative_url }}">Download</a>
+</dl>


### PR DESCRIPTION
I'm sorry, I didn't have a dev environment set up and thought I could make a quick fix, but I actually made it stop showing up as a link at all. I'm not sure why the syntax isn't being processed the way I expect, and at some point I'd like to make the code of this page less fragile, but for now here's a fix that I've actually tested.